### PR TITLE
Added package description to homebrew package manifest

### DIFF
--- a/schemas/HomebrewPackageManifest.schema
+++ b/schemas/HomebrewPackageManifest.schema
@@ -29,7 +29,7 @@
             "type": "string",
             "description": "The title of the application as it shows in the Launcher and the app window. The application title is unique, set once."
         },
-         "description": {
+         "appDescription": {
             "type": "string",
             "description": "The description of the application shown in the application details page."
         },

--- a/schemas/HomebrewPackageManifest.schema
+++ b/schemas/HomebrewPackageManifest.schema
@@ -29,6 +29,10 @@
             "type": "string",
             "description": "The title of the application as it shows in the Launcher and the app window. The application title is unique, set once."
         },
+         "description": {
+            "type": "string",
+            "description": "The description of the application shown in the application details page."
+        },
         "iconUri": {
             "type": "string",
             "description": "Image displayed for your app. This is a URL to an image, or data: encoded URI"


### PR DESCRIPTION
This PR adds the `appDescription` field to be used by the Homebrew Channel.

https://github.com/webosbrew/webos-homebrew-channel/issues/12