### PR TITLE
Added appDescription to the package manifest

### DIFF
--- a/schemas/HomebrewPackageManifest.schema
+++ b/schemas/HomebrewPackageManifest.schema
@@ -29,6 +29,10 @@
             "type": "string",
             "description": "The title of the application as it shows in the Launcher and the app window. The application title is unique, set once."
         },
+         "appDescription": {
+            "type": "string",
+            "description": "The description of the application shown in the application details page."
+        },
         "iconUri": {
             "type": "string",
             "description": "Image displayed for your app. This is a URL to an image, or data: encoded URI"


### PR DESCRIPTION
This PR adds the appDescription field to be used by the Homebrew Channel.

webosbrew/webos-homebrew-channel#12
 

(closed previous PR due to incorrect commiter)